### PR TITLE
Added a 1s wait in UncaughtExceptionHandlers

### DIFF
--- a/src/main/java/net/gini/dropwizard/gelf/logging/UncaughtExceptionHandlers.java
+++ b/src/main/java/net/gini/dropwizard/gelf/logging/UncaughtExceptionHandlers.java
@@ -43,6 +43,9 @@ public final class UncaughtExceptionHandlers {
         @Override
         public void uncaughtException(Thread t, Throwable e) {
             LOGGER.error(String.format("Caught an exception in %s.  Shutting down.", t), e);
+            try {
+                Thread.sleep(1000);
+            } catch (InterruptedException ie) {}
             runtime.exit(1);
         }
     }


### PR DESCRIPTION
Since all loggers in Dropwizard are now asynchronous, the exceptions from here never get logged, as the JVM terminates before the async appender flushes the message. The 1s delay seems to be enough for the message to be sent through.
