### PR TITLE
Migrate to logstash-gelf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Dropwizard GELF Changelog
 =========================
 
+0.9.2-2
+-------
+
+* Migrate to [logstash-gelf](http://logging.paluch.biz/)
+
+
 0.9.2-1
 -------
 

--- a/pom.xml
+++ b/pom.xml
@@ -92,15 +92,9 @@
             <artifactId>dropwizard-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>me.moocar</groupId>
-            <artifactId>logback-gelf</artifactId>
-            <version>0.12</version>
-            <exclusions>
-                <exclusion>
-                    <artifactId>logback-classic</artifactId>
-                    <groupId>ch.qos.logback</groupId>
-                </exclusion>
-            </exclusions>
+            <groupId>biz.paluch.logging</groupId>
+            <artifactId>logstash-gelf</artifactId>
+            <version>1.8.0</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/src/main/java/net/gini/dropwizard/gelf/logging/GelfBootstrap.java
+++ b/src/main/java/net/gini/dropwizard/gelf/logging/GelfBootstrap.java
@@ -6,13 +6,13 @@ import com.google.common.base.Optional;
 import org.slf4j.LoggerFactory;
 
 /**
- * A class adding a configured {@link me.moocar.logbackgelf.GelfAppender} to the root logger.
+ * A class adding a configured {@link biz.paluch.logging.gelf.logback.GelfLogbackAppender} to the root logger.
  */
 public final class GelfBootstrap {
     private GelfBootstrap() { /* No instance methods */ }
 
     /**
-     * Bootstrap the SLF4J root logger with a configured {@link me.moocar.logbackgelf.GelfAppender}.
+     * Bootstrap the SLF4J root logger with a configured {@link biz.paluch.logging.gelf.logback.GelfLogbackAppender}.
      *
      * @param name            The facility to use in the GELF messages
      * @param host            The host of the Graylog2 server
@@ -24,7 +24,7 @@ public final class GelfBootstrap {
     }
 
     /**
-     * Bootstrap the SLF4J root logger with a configured {@link me.moocar.logbackgelf.GelfAppender}.
+     * Bootstrap the SLF4J root logger with a configured {@link biz.paluch.logging.gelf.logback.GelfLogbackAppender}.
      *
      * @param name            The facility to use in the GELF messages
      * @param host            The host of the Graylog2 server
@@ -39,7 +39,7 @@ public final class GelfBootstrap {
         gelf.setThreshold(Level.WARN);
         gelf.setHost(host);
         gelf.setPort(port);
-        gelf.setHostName(hostName);
+        gelf.setOriginHost(hostName);
 
         final Logger root = (Logger) LoggerFactory.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME);
 

--- a/src/test/java/net/gini/dropwizard/gelf/logging/GelfAppenderFactoryTest.java
+++ b/src/test/java/net/gini/dropwizard/gelf/logging/GelfAppenderFactoryTest.java
@@ -1,21 +1,18 @@
 package net.gini.dropwizard.gelf.logging;
 
-import com.google.common.base.Optional;
-
-import org.junit.Test;
-
-import java.io.IOException;
-
 import ch.qos.logback.classic.AsyncAppender;
 import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.Appender;
 import ch.qos.logback.core.helpers.NOPAppender;
+import com.google.common.base.Optional;
 import io.dropwizard.configuration.ConfigurationException;
+import org.junit.Test;
+
+import java.io.IOException;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsNull.nullValue;
 import static org.junit.Assert.assertThat;
 
 public class GelfAppenderFactoryTest {
@@ -26,17 +23,16 @@ public class GelfAppenderFactoryTest {
     public void hasValidDefaults() throws IOException, ConfigurationException {
         final GelfAppenderFactory factory = new GelfAppenderFactory();
 
-        assertThat("default Graylog2 host is 'localhost'", factory.getHost(), is("localhost"));
-        assertThat("default Graylog2 port is 12201", factory.getPort(), is(12201));
-        assertThat("default hostname is absent", factory.getHostName(), is(Optional.<String>absent()));
-        assertThat("default server version is 0.9.6", factory.getServerVersion(), is("0.9.6"));
+        assertThat("default host is 'localhost'", factory.getHost(), is("localhost"));
+        assertThat("default port is 12201", factory.getPort(), is(12201));
+        assertThat("default origin host is absent", factory.getOriginHost(), is(Optional.<String>absent()));
         assertThat("default facility is absent", factory.getFacility().isPresent(), is(false));
-        assertThat("default chunk threshold is 1000", factory.getChunkThreshold(), is(1000));
-        assertThat("default message pattern is %m%rEx", factory.getMessagePattern(), is("%m%rEx"));
-        assertThat("default short message pattern is unset", factory.getShortMessagePattern(), nullValue());
         assertThat("default additional fields are empty", factory.getAdditionalFields().isEmpty(), is(true));
-        assertThat("default static additional fields are empty", factory.getStaticFields().isEmpty(), is(true));
-        assertThat("default field types are empty", factory.getFieldTypes().isEmpty(), is(true));
+        assertThat("default field types are empty", factory.getAdditionalFieldTypes().isEmpty(), is(true));
+        assertThat("default MDC fields are empty", factory.getMdcFields().isEmpty(), is(true));
+        assertThat("default dynamic MDC fields are empty", factory.getDynamicMdcFields().isEmpty(), is(true));
+        assertThat("default maximum message size is 8192", factory.getMaximumMessageSize(), is(8192));
+        assertThat("default timestamp pattern is \"yyyy-MM-dd HH:mm:ss,SSSS\"", factory.getTimestampPattern(), is("yyyy-MM-dd HH:mm:ss,SSSS"));
     }
 
     @Test(expected = NullPointerException.class)


### PR DESCRIPTION
The original [Logback GELF appender](https://github.com/Moocar/logback-gelf) isn't maintained anymore and lacks some features (e. g. different transports like TCP or HTTP).

This PR migrates the dropwizard-gelf project to the well-maintained and feature-rich [logstash-gelf](http://logging.paluch.biz/).

Unfortunately the configuration changed in various places but the updated README.md file should be enough to point users to the correct settings.

Closes #16 