### PR TITLE
Upgrade to Dropwizard 1.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.site.deploy.skip>true</maven.site.deploy.skip>
-        <dropwizard.version>1.1.0</dropwizard.version>
+        <dropwizard.version>1.2.0</dropwizard.version>
     </properties>
 
     <dependencyManagement>

--- a/src/main/java/net/gini/dropwizard/gelf/logging/GelfAppenderFactory.java
+++ b/src/main/java/net/gini/dropwizard/gelf/logging/GelfAppenderFactory.java
@@ -32,10 +32,6 @@ public class GelfAppenderFactory extends AbstractAppenderFactory<ILoggingEvent> 
     private boolean enabled = true;
 
     @JsonProperty
-    @NotNull
-    private Level threshold = Level.ALL;
-
-    @JsonProperty
     private Optional<String> facility = Optional.empty();
 
     @JsonProperty
@@ -84,14 +80,6 @@ public class GelfAppenderFactory extends AbstractAppenderFactory<ILoggingEvent> 
     @JsonProperty
     @NotNull
     private String timestampPattern = "yyyy-MM-dd HH:mm:ss,SSSS";
-
-    public Level getThreshold() {
-        return threshold;
-    }
-
-    public void setThreshold(Level threshold) {
-        this.threshold = threshold;
-    }
 
     public Optional<String> getFacility() {
         return facility;

--- a/src/main/java/net/gini/dropwizard/gelf/logging/GelfBootstrap.java
+++ b/src/main/java/net/gini/dropwizard/gelf/logging/GelfBootstrap.java
@@ -1,6 +1,5 @@
 package net.gini.dropwizard.gelf.logging;
 
-import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import io.dropwizard.logging.async.AsyncLoggingEventAppenderFactory;
 import io.dropwizard.logging.filter.ThresholdLevelFilterFactory;
@@ -39,7 +38,7 @@ public final class GelfBootstrap {
         // initially configure for WARN+ GELF logging
         final GelfAppenderFactory gelf = new GelfAppenderFactory();
         gelf.setIncludeFullMDC(true);
-        gelf.setThreshold(Level.WARN);
+        gelf.setThreshold("WARN");
         gelf.setHost(host);
         gelf.setPort(port);
         gelf.setOriginHost(hostName);

--- a/src/test/java/net/gini/dropwizard/gelf/logging/GelfAppenderFactoryTest.java
+++ b/src/test/java/net/gini/dropwizard/gelf/logging/GelfAppenderFactoryTest.java
@@ -35,6 +35,7 @@ public class GelfAppenderFactoryTest {
         assertThat("default dynamic MDC fields are empty", factory.getDynamicMdcFields().isEmpty(), is(true));
         assertThat("default maximum message size is 8192", factory.getMaximumMessageSize(), is(8192));
         assertThat("default timestamp pattern is \"yyyy-MM-dd HH:mm:ss,SSSS\"", factory.getTimestampPattern(), is("yyyy-MM-dd HH:mm:ss,SSSS"));
+        assertThat("default threshold is ALL", factory.getThreshold(), is("ALL"));
     }
 
     @Test


### PR DESCRIPTION
Upgrade to the latest version of Dropwizard and remove unnecessary field `threshold` from `GelfAppenderFactory`.  It's already present in `AbstractAppenderFactory`, so the `threshold` field in
`GelfAppenderFactory` just shadowed it. Unfortunately in 1.2.0, the type of public getters of the `threshold` field in `AbstractAppenderFactory` changed their signature (they are now serialized and deserialized as
strings), so `GelfAppenderFactory` didn't compile. But because this field is superfluous, we can safely remove it.