### PR TITLE
Implement CountingServletOutputStream#setWriteListener(WriteListener)

### DIFF
--- a/src/main/java/net/gini/dropwizard/gelf/filters/GelfLoggingFilter.java
+++ b/src/main/java/net/gini/dropwizard/gelf/filters/GelfLoggingFilter.java
@@ -238,6 +238,11 @@ public class GelfLoggingFilter implements Filter {
             outputStream.write(b);
         }
 
+        @Override
+        public void write(final byte[] b, final int off, final int len) throws IOException {
+            outputStream.write(b, off, len);
+        }
+
         public long getCount() {
             return outputStream.getCount();
         }

--- a/src/main/java/net/gini/dropwizard/gelf/filters/GelfLoggingFilter.java
+++ b/src/main/java/net/gini/dropwizard/gelf/filters/GelfLoggingFilter.java
@@ -211,9 +211,14 @@ public class GelfLoggingFilter implements Filter {
      */
     private static final class CountingServletOutputStream extends ServletOutputStream {
 
+        /**
+         * The underlying stream that is wrapped by CountingOutputStream.
+         */
+        private final ServletOutputStream underlyingStream;
         private final CountingOutputStream outputStream;
 
         private CountingServletOutputStream(ServletOutputStream servletOutputStream) {
+            this.underlyingStream = servletOutputStream;
             this.outputStream = new CountingOutputStream(servletOutputStream);
         }
 
@@ -243,18 +248,23 @@ public class GelfLoggingFilter implements Filter {
             outputStream.write(b, off, len);
         }
 
+        @Override
+        public void flush() throws IOException {
+            underlyingStream.flush();
+        }
+
         public long getCount() {
             return outputStream.getCount();
         }
 
         @Override
         public boolean isReady() {
-            return true;
+            return underlyingStream.isReady();
         }
 
         @Override
         public void setWriteListener(WriteListener writeListener) {
-            // NOP
+            underlyingStream.setWriteListener(writeListener);
         }
     }
 


### PR DESCRIPTION
@madmuffin1 noticed and demonstrated that we don't really confirm to the servlet spec, as we don't implement `CountingServletOutputStream#setWriteListener(WriteListener)`.

This merge request implements it by delegating it to the underlying `ServletOutputStream`. It is based on @madmuffin1 's work.

Fixes #27