### PR TITLE
Improve MAVEN build Performance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.site.deploy.skip>true</maven.site.deploy.skip>
         <dropwizard.version>2.0.28</dropwizard.version>
+    	<closeTestReports>true</closeTestReports>
     </properties>
 
     <dependencyManagement>
@@ -171,6 +172,9 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>2.22.2</version>
+                    <configuration>
+                    	<disableXmlReport>${closeTestReports}</disableXmlReport>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION

That report generation takes time, slowing down the overall build. Reports are definitely useful, but do you need them every time you run the build. We can conditionally disable generating test reports by setting `<disableXmlReport>true<disableXmlReport>`. If you need to generate reports, just add `-DcloseTestReports=false` to the end of mvn build command.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
